### PR TITLE
working solution for 20-get-api-reviews.  pagination done at JS level…

### DIFF
--- a/controllers/controller.js
+++ b/controllers/controller.js
@@ -1,6 +1,6 @@
 const { selectCategories, selectReviews, selectReviewsById,selectComments, insertComments, selectUsers,updateVotesByReviewId, deleteComment,selectUserByUsername, updateVotesByCommentId, insertReview } = require('../models/model.js')
 const app = require('../app.js')
-const {bodyTypeChecker,categoryChecker} = require('../db/utils')
+const {bodyTypeChecker,categoryChecker, validateAndPaginate} = require('../db/utils')
 const fs = require('fs/promises')
 
 
@@ -15,7 +15,11 @@ exports.getReviews = (req,res,next) => {
     let promises = [categoryChecker(req,res),selectReviews(req.query)]
     return Promise.all(promises)
     .then(([msg,reviews]) => {
-        res.status(200).send({reviews})
+        return validateAndPaginate(reviews,req)
+
+    })
+    .then(({results,total_count}) => {
+        res.status(200).send({reviews:results,total_count})
     })
     .catch((err) => {
         next(err)


### PR DESCRIPTION
working solution for 20-get-api-reviews.  pagination done at JS level… after querying SQL for *all* results
open to refactor at later date to utilise SQL LIMIT and OFFSET keywords to handle the pagination at SQL level.  some minor tweaks to old test blocks on get /api/reviews end-point to reflect new default limit of 10